### PR TITLE
Pin pytest to latest version 3.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 faker
 pytz
-pytest
+pytest==3.2.2


### PR DESCRIPTION

pytest is not pinned to a specific version.

I'm pinning it to the latest version **3.2.2** for now.




Happy merging! 🤖

---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
